### PR TITLE
Fixed typo

### DIFF
--- a/translations/fr/LC_MESSAGES/ref.po
+++ b/translations/fr/LC_MESSAGES/ref.po
@@ -36014,7 +36014,7 @@ msgid ""
 "Note that any text-based field -- such as ``CharField`` or ``EmailField`` --"
 " always cleans the input into a Unicode string. We'll cover the encoding "
 "implications later in this document."
-msgstr "Notez que tout champ basé sur du texte, tel que ``CharField`` ou ``EmailField``, nettoie toujours le contenu saisi pour en faire une chaîne Unicode. Noua aborderons les implications du codage plus loin dans ce document."
+msgstr "Notez que tout champ basé sur du texte, tel que ``CharField`` ou ``EmailField``, nettoie toujours le contenu saisi pour en faire une chaîne Unicode. Nous aborderons les implications du codage plus loin dans ce document."
 
 # 8a07bf08523c4f529f24c22eaac0b3f0
 #: ../../../../1.8/docs/ref/forms/api.txt:353


### PR DESCRIPTION
Fixed a very little typo in the Django forms ref page.

The same typo appears on stable/1.7.x and stable/1.6.x branches.