### PR TITLE
Add new translation

### DIFF
--- a/translations/es/LC_MESSAGES/intro.po
+++ b/translations/es/LC_MESSAGES/intro.po
@@ -11,6 +11,7 @@
 # juanda097 <juanda097@openmailbox.org>, 2014-2015
 # Samuel David Ramirez Mantione <venezuelapoliglota@hotmail.com>, 2015-2016
 # Victor Manuel Castillo <mini.guero@hotmail.com>, 2013
+# Carlos Camacho <carloscamachoucv@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: django-docs\n"
@@ -626,6 +627,8 @@ msgid ""
 "After reading those, if you want something a little meatier to sink your "
 "teeth into, there's always the Python :mod:`unittest` documentation."
 msgstr ""
+"Despues de leerlos, si quieres algo más dificil con que practicar, "
+"siempre estará la documentación de Python :mod:`unittest`. "
 
 msgid "Running your new test"
 msgstr "Ejecutando su nueva prueba"


### PR DESCRIPTION
Added translation for:

"After reading those, if you want something a little meatier to sink your "
"teeth into, there's always the Python :mod:`unittest` documentation."

"Despues de leerlos, si quieres algo más dificil con que practicar, "
"siempre estará la documentación de Python :mod:`unittest`. "